### PR TITLE
Allow tmp user to assume role aws-admin

### DIFF
--- a/aws_iam_role.aws-admin.tf
+++ b/aws_iam_role.aws-admin.tf
@@ -5,7 +5,8 @@ data "aws_iam_policy_document" "aws-admin" {
     principals {
       type = "AWS"
       identifiers = [
-        aws_iam_user.aleks.arn
+        aws_iam_user.aleks.arn,
+        aws_iam_user.tmp.arn
       ]
     }
   }


### PR DESCRIPTION
aws-admin role is used by aws-s3-control - a deprecated repo.
the tmp user needs aws-admin to remove resources created by this repo
