### PR TITLE
fix(backup): support AWS provider v6 by relaxing version constraint

### DIFF
--- a/modules/backup/terraform.tf
+++ b/modules/backup/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "5.100.0"
+      version = ">= 5.11, < 7.0"
     }
   }
 }


### PR DESCRIPTION
The backup child module pins hashicorp/aws to 5.100.0,
which excludes provider v6.

This change relaxes the constraint to:

>= 5.11, < 7.0

to support both v5 and v6.

Closes #73