### PR TITLE
refactor: modernize module to align with InfraHouse coding standards

### DIFF
--- a/.claude/plans/org-governance-tester-role.md
+++ b/.claude/plans/org-governance-tester-role.md
@@ -1,0 +1,118 @@
+# Plan: Create Tester Role for terraform-aws-org-governance in 990466748045
+
+## Context
+
+`terraform-aws-org-governance` is a new module for centralized AWS Organizations governance,
+deployed in the management account (990466748045). Its first use case is a Lambda that enforces
+CloudWatch log retention across all member accounts by assuming `AWSControlTowerExecution`.
+
+The module's CI tests need a tester role in the **management account** -- not in 303467602807
+where other tester roles live. The 303467602807 tester role
+([aws-control-303467602807#251](https://github.com/infrahouse/aws-control-303467602807/pull/251))
+is useless for this module because it lacks org-level API access and cross-account assume
+capabilities.
+
+This is the first tester role in `aws-control` (990466748045). There is no existing
+`module-tester-role` module here, so we need to create the role directly or adapt the pattern.
+
+## Test Flow (what the tester role must support)
+
+1. **Deploy** the module in 990466748045 (Lambda, IAM role, EventBridge, CloudWatch)
+2. **Arrange**: Assume `AWSControlTowerExecution` into a member account, create a test
+   CloudWatch log group with no retention
+3. **Act**: Invoke the Lambda
+4. **Assert**: Verify the test log group now has 365-day retention
+5. **Teardown**: Delete the test log group, destroy the module resources
+
+## Required Permissions
+
+The tester role needs:
+
+### AWS Organizations (read-only)
+- `organizations:ListAccounts`
+- `organizations:DescribeOrganization`
+
+### STS (cross-account)
+- `sts:AssumeRole` on `arn:aws:iam::*:role/AWSControlTowerExecution`
+  (or scoped to `local.managed_account_ids`)
+
+### Lambda (deploy + invoke)
+- `lambda:*` (create, update, delete, invoke the module's Lambda)
+
+### IAM (create module roles + policies)
+- `iam:*` (create/delete the Lambda execution role and its policies)
+
+### EventBridge (deploy scheduled trigger)
+- `events:*` (create/delete the scheduled rule that triggers the Lambda)
+
+### CloudWatch Logs (for the Lambda's own log group + test assertions)
+- `logs:*` (create/delete log groups, set/verify retention)
+
+### S3 (if the Lambda code is packaged in S3)
+- `s3:*` on relevant buckets
+
+### Alternatively: AdministratorAccess
+
+Given the breadth of permissions and the pattern from 303467602807 (`grant_admin_permissions = true`
+on all tester roles), the simplest approach is to grant `AdministratorAccess` to this tester role
+as well. The role is scoped by its trust policy (GitHub Actions OIDC for the specific repo).
+
+## Implementation (chosen: github-role module)
+
+Uses `infrahouse/github-role/aws` v1.4.0 — a lightweight module that creates a single IAM role
+with GitHub OIDC trust. Simpler than `gha-admin` (no extra state-manager/admin roles).
+
+**File:** `aws_iam_role.org_governance_tester.tf`
+
+```hcl
+module "org_governance_tester" {
+  source  = "infrahouse/github-role/aws"
+  version = "1.4.0"
+
+  gh_org_name          = "infrahouse"
+  repo_name            = "terraform-aws-org-governance"
+  role_name            = "org-governance-tester"
+  max_session_duration = 43200
+
+  depends_on = [module.github_connector]
+}
+
+resource "aws_iam_role_policy_attachment" "org_governance_tester_admin" {
+  role       = module.org_governance_tester.github_role_name
+  policy_arn = data.aws_iam_policy.administrator-access.arn
+}
+```
+
+The `github-role` module internally looks up the OIDC provider via
+`data.aws_iam_openid_connect_provider`, so `depends_on` on `module.github_connector`
+ensures the provider exists first.
+
+## terraform-aws-org-governance test configuration
+
+Once the role exists, the module's test root needs:
+
+**`tests/test_module.py`** -- test role ARN:
+```
+arn:aws:iam::990466748045:role/org-governance-tester
+```
+
+**`Makefile`** -- override the default test role:
+```makefile
+TEST_ROLE ?= arn:aws:iam::990466748045:role/org-governance-tester
+```
+
+## Verification
+
+1. `terraform plan` shows the new role + policy attachment (2-3 resources)
+2. Apply, then verify the role exists:
+   `aws iam get-role --role-name org-governance-tester`
+3. Verify GitHub Actions can assume it from the `terraform-aws-org-governance` repo
+4. Verify SSO admin can assume it for local testing
+
+## Open Questions
+
+- Should we scope `sts:AssumeRole` on `AWSControlTowerExecution` to specific accounts instead of
+  granting full `AdministratorAccess`? Full admin is the existing pattern, and the trust policy
+  limits who can assume the role, but it's worth noting.
+- Should the tester role in 303467602807 (from PR #251) be removed since it's not useful for this
+  module?

--- a/.github/workflows/terraform-CI.yml
+++ b/.github/workflows/terraform-CI.yml
@@ -52,7 +52,7 @@ jobs:
 
       # Prepare Python environment
       - name: Setup Python Environment
-        run: make bootstrap-ci
+        run: make bootstrap
 
       # Run all required linters
       - name: Code Style Check

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ tf.plan
 /plan.stderr
 /plan.stdout
 .claude/reviews
+/.claude/*.local.json

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -2,25 +2,25 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "5.100.0"
-  constraints = ">= 5.11.0, ~> 5.11, ~> 5.56, < 7.0.0"
+  version     = "6.38.0"
+  constraints = ">= 5.11.0, >= 5.56.0, ~> 6.0, < 7.0.0"
   hashes = [
-    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
-    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
-    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
-    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
-    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
-    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
-    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "h1:7F3W4qGLTbr4aploSI8eIqE4AueoNe/Tq5Osuo0IgJ4=",
+    "zh:143f118ae71059a7a7026c6b950da23fef04a06e2362ffa688bef75e43e869ed",
+    "zh:29ee220a017306effd877e1280f8b2934dc957e16e0e72ca0222e5514d0db522",
+    "zh:3a31baabf7aea7aa7669f5a3d76f3445e0e6cce5e9aea0279992765c0df12aee",
+    "zh:4c1908e62040dbc9901d4426ffb253f53e5dae9e3e1a9125311291ee265c8d8c",
+    "zh:550f4789f5f5b00e16118d4c17770be3ef4535d6b6928af1cf91ebd30f2c263b",
+    "zh:6537b7b70bf2c127771b0b84e4b726c834d10666b6104f017edae50c67ebae37",
     "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
-    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
-    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
-    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
-    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
-    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
-    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
-    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
-    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+    "zh:af2f9cea0c8bdf5b2a2391f2d179a946c117196f7c829b919673cae3b71d2943",
+    "zh:c53ffa685381aa4e73158fd9f529239f95938dea330e7aca0b32e7b2a1210432",
+    "zh:d0995e1d64a7ec8bbc79fc3fbec3749f989e07f211a318705c37cd6a7c7d19e4",
+    "zh:d2348ffcffc1282983d7a5838dd5d61f372152fe6c0d10868cd6473352318750",
+    "zh:e449312efb73e4747165e689302a68a1df8ba5755e7f59097069acf82c94f011",
+    "zh:ec3a538d264ef79380e56fdf107ffb6c0446814f07fc5890c36855fe1e03196b",
+    "zh:f441e69699b22e32c96a8cdd3bbe694ed302c0dcfe867cd9bd683a16df362714",
+    "zh:f6f8eaa605ff902234d7e9bdab4fda977185fce14f8576f7b622c914c7d98008",
   ]
 }
 
@@ -28,6 +28,7 @@ provider "registry.terraform.io/hashicorp/random" {
   version     = "3.8.1"
   constraints = "~> 3.5"
   hashes = [
+    "h1:Eexl06+6J+s75uD46+WnZtpJZYRVUMB0AiuPBifK6Jc=",
     "h1:u8AKlWVDTH5r9YLSeswoVEjiY72Rt4/ch7U+61ZDkiQ=",
     "zh:08dd03b918c7b55713026037c5400c48af5b9f468f483463321bd18e17b907b4",
     "zh:0eee654a5542dc1d41920bbf2419032d6f0d5625b03bd81339e5b33394a3e0ae",

--- a/aws_iam_role.org_governance_tester.tf
+++ b/aws_iam_role.org_governance_tester.tf
@@ -1,0 +1,12 @@
+module "org_governance_tester" {
+  source = "./modules/module-tester-role"
+
+  gh_org_name             = "infrahouse"
+  repo_name               = "terraform-aws-org-governance"
+  role_name               = "org-governance-tester"
+  max_session_duration    = 43200
+  grant_admin_permissions = true
+  trusted_iam_user_arn    = { sso-admin : tolist(data.aws_iam_roles.sso_admin.arns)[0] }
+
+  depends_on = [module.github_connector]
+}

--- a/cost.tf
+++ b/cost.tf
@@ -3,9 +3,10 @@ module "cost-alert" {
     aws = aws.aws-990466748045-ue1
   }
   source             = "registry.infrahouse.com/infrahouse/cost-alert/aws"
-  version            = "1.0.0"
+  version            = "1.1.1"
   alert_name         = "[infrahouse]: AWS daily cost"
   cost_threshold     = 18
   period_hours       = 24
   notification_email = "aleks@infrahouse.com"
+  environment        = local.default_tags.environment
 }

--- a/modules/backup/terraform.tf
+++ b/modules/backup/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "5.100.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/modules/module-tester-role/data_sources.tf
+++ b/modules/module-tester-role/data_sources.tf
@@ -1,0 +1,87 @@
+locals {
+  gha_hostname = "token.actions.githubusercontent.com"
+}
+
+data "aws_iam_openid_connect_provider" "github" {
+  url = "https://${local.gha_hostname}"
+}
+data "aws_iam_policy_document" "pytest-permissions" {
+  statement {
+    actions = [
+      "dynamodb:ListTagsOfResource",
+      "dynamodb:TagResource",
+      "ec2:DescribeRegions",
+      "iam:TagPolicy",
+      "iam:TagRole",
+      "s3:GetBucketTagging",
+      "s3:PutBucketTagging"
+    ]
+    resources = ["*"]
+  }
+}
+
+data "aws_caller_identity" "current" {}
+
+data "aws_iam_policy_document" "role-trust" {
+  dynamic "statement" {
+    for_each = merge(
+      var.trusted_iam_user_arn,
+    )
+    content {
+      actions = ["sts:AssumeRole"]
+      principals {
+        type        = "AWS"
+        identifiers = [statement.value]
+      }
+    }
+  }
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+    }
+    condition {
+      variable = "aws:PrincipalArn"
+      test     = "ArnEquals"
+      values = [
+        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.role_name}"
+      ]
+    }
+
+  }
+  statement {
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+    principals {
+      type = "Federated"
+      identifiers = [
+        data.aws_iam_openid_connect_provider.github.arn
+      ]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "${local.gha_hostname}:aud"
+      values = [
+        "sts.amazonaws.com"
+      ]
+    }
+    condition {
+      test     = "StringLike"
+      variable = "${local.gha_hostname}:sub"
+      values = [
+        "repo:${var.gh_org_name}/${var.repo_name}:*"
+      ]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "role-permissions" {
+  statement {
+    actions   = length(var.role_permissions) > 0 ? var.role_permissions : ["sts:GetCallerIdentity"]
+    resources = ["*"]
+  }
+}
+
+data "aws_iam_policy" "administrator-access" {
+  name = "AdministratorAccess"
+}

--- a/modules/module-tester-role/main.tf
+++ b/modules/module-tester-role/main.tf
@@ -1,0 +1,32 @@
+resource "aws_iam_policy" "pytest-permissions" {
+  name_prefix = "pytest-permissions"
+  policy      = data.aws_iam_policy_document.pytest-permissions.json
+}
+
+resource "aws_iam_policy" "role-permissions" {
+  name_prefix = "${var.role_name}-permissions"
+  policy      = data.aws_iam_policy_document.role-permissions.json
+}
+
+resource "aws_iam_role" "role-tester" {
+  name                 = var.role_name
+  description          = "Role to test module ${var.gh_org_name}/${var.repo_name}"
+  assume_role_policy   = data.aws_iam_policy_document.role-trust.json
+  max_session_duration = var.max_session_duration
+}
+
+resource "aws_iam_role_policy_attachment" "role-pytest-permissions" {
+  policy_arn = aws_iam_policy.pytest-permissions.arn
+  role       = aws_iam_role.role-tester.name
+}
+
+resource "aws_iam_role_policy_attachment" "role-permissions" {
+  policy_arn = aws_iam_policy.role-permissions.arn
+  role       = aws_iam_role.role-tester.name
+}
+
+resource "aws_iam_role_policy_attachment" "role-admin-permissions" {
+  count      = var.grant_admin_permissions ? 1 : 0
+  policy_arn = data.aws_iam_policy.administrator-access.arn
+  role       = aws_iam_role.role-tester.name
+}

--- a/modules/module-tester-role/outputs.tf
+++ b/modules/module-tester-role/outputs.tf
@@ -1,0 +1,14 @@
+output "role_arn" {
+  description = "Role ARN."
+  value       = aws_iam_role.role-tester.arn
+}
+
+output "role_name" {
+  description = "Role name."
+  value       = aws_iam_role.role-tester.name
+}
+
+output "permissions_policy_arn" {
+  description = "ARN of the policy with the role permissions."
+  value       = aws_iam_policy.role-permissions.arn
+}

--- a/modules/module-tester-role/terraform.tf
+++ b/modules/module-tester-role/terraform.tf
@@ -1,4 +1,5 @@
 terraform {
+  required_version = "~> 1.5"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/modules/module-tester-role/variables.tf
+++ b/modules/module-tester-role/variables.tf
@@ -1,0 +1,34 @@
+variable "gh_org_name" {
+  description = "GitHub organization name."
+  type        = string
+}
+
+variable "grant_admin_permissions" {
+  description = "Whether grant admin permissions to the role."
+  type        = bool
+  default     = false
+}
+variable "max_session_duration" {
+  description = "Maximum session duration (in seconds) that you want to set for the specified role."
+  default     = 3600
+}
+
+variable "repo_name" {
+  description = "Repository name in GitHub. Without the organization part."
+}
+
+variable "role_name" {
+  description = "Role name"
+  type        = string
+}
+variable "role_permissions" {
+  description = "List of actions the role can do. The action will be allowed on all resources i.e. `*`."
+  default     = []
+  type        = list(string)
+}
+
+variable "trusted_iam_user_arn" {
+  description = "Map of ARN of a user or role that can assume the tester role. Useful for local testing."
+  default     = {}
+  type        = map(string)
+}

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,4 +1,0 @@
-boto3 ~= 1.26
-infrahouse-toolkit ~=2.32
-pyhcl ~= 0.4
-yamllint ~= 1.29

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-black ~=25.1
-Sphinx ~=8.0
--r requirements-ci.txt
+infrahouse-core ~= 0.28
+pytest-infrahouse ~= 0.24
+yamllint ~= 1.38

--- a/terraform.tf
+++ b/terraform.tf
@@ -12,7 +12,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "5.100.0"
+      version = "~> 6.0"
     }
   }
 }


### PR DESCRIPTION
- Update tests to use pytest-infrahouse fixtures, parametrize AWS provider
  versions (5.x and 6.x), and add resource assertions
- Add SNS topic encryption at rest (alias/aws/sns)
- Add outputs.tf with sns_topic_arn and cloudwatch_alarm_arn
- Add environment variable, module tags, and module_version tracking
- Add variable validation blocks (cost_threshold, notification_email, period_hours)
- Modernize Makefile with test-keep, test-clean, release targets, commit-msg hook
- Add README badges, required sections, and architecture diagram
- Add docs pages (getting-started, configuration), examples/basic, CHANGELOG.md
- Add .bumpversion.cfg, .checkov.yml, locals.tf
