### PR TITLE
feat: import Control Tower OU baselines into Terraform

### DIFF
--- a/ct.tf
+++ b/ct.tf
@@ -7,3 +7,165 @@ resource "aws_controltower_landing_zone" "root" {
   manifest_json = file("${path.module}/files/LandingZoneManifest.json")
   version       = "3.3"
 }
+
+locals {
+  ct_home_region             = aws_controltower_landing_zone.root.region
+  baseline_identity_center   = "arn:aws:controltower:${local.ct_home_region}::baseline/LN25R72TTG6IGPTQ"
+  baseline_audit             = "arn:aws:controltower:${local.ct_home_region}::baseline/4T4HA1KMO10S6311"
+  baseline_log_archive       = "arn:aws:controltower:${local.ct_home_region}::baseline/J8HX46AHS5MIKQPD"
+  baseline_aws_control_tower = "arn:aws:controltower:${local.ct_home_region}::baseline/17BSJV3IGJ2QSGA2"
+  # Enabled baseline ARN for IdentityCenter — hardcoded until account-level baselines can be imported
+  identity_center_enabled_baseline_arn = "arn:aws:controltower:us-west-1:990466748045:enabledbaseline/XAP0DVO6CUI4940JO"
+}
+
+# Account-level baselines are commented out due to a provider bug:
+# hashicorp/terraform-provider-aws#45871
+# The provider doesn't read baseline_version during import for account-targeted
+# baselines, causing forced replacement. Uncomment when the bug is fixed.
+#
+# import {
+#   to = aws_controltower_baseline.identity_center
+#   id = "arn:aws:controltower:us-west-1:990466748045:enabledbaseline/XAP0DVO6CUI4940JO"
+# }
+#
+# resource "aws_controltower_baseline" "identity_center" {
+#   baseline_identifier = local.baseline_identity_center
+#   baseline_version    = "4.0"
+#   target_identifier   = aws_organizations_organization.infrahouse.master_account_arn
+# }
+#
+# import {
+#   to = aws_controltower_baseline.audit
+#   id = "arn:aws:controltower:us-west-1:990466748045:enabledbaseline/XADCNRRD70A4940MG"
+# }
+#
+# resource "aws_controltower_baseline" "audit" {
+#   baseline_identifier = local.baseline_audit
+#   baseline_version    = "4.0"
+#   target_identifier   = aws_organizations_account.audit.arn
+# }
+#
+# import {
+#   to = aws_controltower_baseline.log_archive
+#   id = "arn:aws:controltower:us-west-1:990466748045:enabledbaseline/XAHOV133Y2L4940L0"
+# }
+#
+# resource "aws_controltower_baseline" "log_archive" {
+#   baseline_identifier = local.baseline_log_archive
+#   baseline_version    = "4.0"
+#   target_identifier   = aws_organizations_account.log_archive.arn
+# }
+
+# AWSControlTowerBaseline (on OUs)
+
+import {
+  to = aws_controltower_baseline.infrastructure
+  id = "arn:aws:controltower:us-west-1:990466748045:enabledbaseline/XOH16ARMKWD4942WE"
+}
+
+resource "aws_controltower_baseline" "infrastructure" {
+  baseline_identifier = local.baseline_aws_control_tower
+  baseline_version    = "4.0"
+  target_identifier   = aws_organizations_organizational_unit.infrastructure.arn
+
+  parameters {
+    key   = "IdentityCenterEnabledBaselineArn"
+    value = local.identity_center_enabled_baseline_arn
+  }
+}
+
+import {
+  to = aws_controltower_baseline.sandbox
+  id = "arn:aws:controltower:us-west-1:990466748045:enabledbaseline/XOKXFUJSAGD4942SG"
+}
+
+resource "aws_controltower_baseline" "sandbox" {
+  baseline_identifier = local.baseline_aws_control_tower
+  baseline_version    = "4.0"
+  target_identifier   = aws_organizations_organizational_unit.sandbox.arn
+
+  parameters {
+    key   = "IdentityCenterEnabledBaselineArn"
+    value = local.identity_center_enabled_baseline_arn
+  }
+}
+
+import {
+  to = aws_controltower_baseline.deployments
+  id = "arn:aws:controltower:us-west-1:990466748045:enabledbaseline/XO0C59G2HSD4944GA"
+}
+
+resource "aws_controltower_baseline" "deployments" {
+  baseline_identifier = local.baseline_aws_control_tower
+  baseline_version    = "4.0"
+  target_identifier   = aws_organizations_organizational_unit.deployments.arn
+
+  parameters {
+    key   = "IdentityCenterEnabledBaselineArn"
+    value = local.identity_center_enabled_baseline_arn
+  }
+}
+
+import {
+  to = aws_controltower_baseline.suspended
+  id = "arn:aws:controltower:us-west-1:990466748045:enabledbaseline/XO3Q2O78DVD49420V"
+}
+
+resource "aws_controltower_baseline" "suspended" {
+  baseline_identifier = local.baseline_aws_control_tower
+  baseline_version    = "4.0"
+  target_identifier   = aws_organizations_organizational_unit.suspended.arn
+
+  parameters {
+    key   = "IdentityCenterEnabledBaselineArn"
+    value = local.identity_center_enabled_baseline_arn
+  }
+}
+
+import {
+  to = aws_controltower_baseline.policy_staging
+  id = "arn:aws:controltower:us-west-1:990466748045:enabledbaseline/XOBSKQ0PBMD4944UY"
+}
+
+resource "aws_controltower_baseline" "policy_staging" {
+  baseline_identifier = local.baseline_aws_control_tower
+  baseline_version    = "4.0"
+  target_identifier   = aws_organizations_organizational_unit.policy_staging.arn
+
+  parameters {
+    key   = "IdentityCenterEnabledBaselineArn"
+    value = local.identity_center_enabled_baseline_arn
+  }
+}
+
+import {
+  to = aws_controltower_baseline.workloads
+  id = "arn:aws:controltower:us-west-1:990466748045:enabledbaseline/XOE4JL0Z8ZD4944QM"
+}
+
+resource "aws_controltower_baseline" "workloads" {
+  baseline_identifier = local.baseline_aws_control_tower
+  baseline_version    = "4.0"
+  target_identifier   = aws_organizations_organizational_unit.workloads.arn
+
+  parameters {
+    key   = "IdentityCenterEnabledBaselineArn"
+    value = local.identity_center_enabled_baseline_arn
+  }
+}
+
+import {
+  to = aws_controltower_baseline.production
+  id = "arn:aws:controltower:us-west-1:990466748045:enabledbaseline/XOG817HWFRD4944DK"
+}
+
+resource "aws_controltower_baseline" "production" {
+  baseline_identifier = local.baseline_aws_control_tower
+  baseline_version    = "4.0"
+  target_identifier   = aws_organizations_organizational_unit.production.arn
+
+  parameters {
+    key   = "IdentityCenterEnabledBaselineArn"
+    value = local.identity_center_enabled_baseline_arn
+  }
+}

--- a/organizations.tf
+++ b/organizations.tf
@@ -1,8 +1,3 @@
-import {
-  to = aws_organizations_organization.infrahouse
-  id = "o-85w62lgze7"
-}
-
 resource "aws_organizations_organization" "infrahouse" {
   aws_service_access_principals = [
     "account.amazonaws.com",
@@ -17,19 +12,9 @@ resource "aws_organizations_organization" "infrahouse" {
   feature_set          = "ALL"
 }
 
-import {
-  to = aws_organizations_organizational_unit.infrastructure
-  id = "ou-k4pv-0kpta53f"
-}
-
 resource "aws_organizations_organizational_unit" "infrastructure" {
   name      = "Infrastructure"
   parent_id = aws_organizations_organization.infrahouse.roots[0].id
-}
-
-import {
-  to = aws_organizations_organizational_unit.production
-  id = "ou-k4pv-zrkq0fya"
 }
 
 resource "aws_organizations_organizational_unit" "production" {
@@ -37,19 +22,9 @@ resource "aws_organizations_organizational_unit" "production" {
   parent_id = aws_organizations_organizational_unit.infrastructure.id
 }
 
-import {
-  to = aws_organizations_organizational_unit.sandbox
-  id = "ou-k4pv-3gyd2btz"
-}
-
 resource "aws_organizations_organizational_unit" "sandbox" {
   name      = "Sandbox"
   parent_id = aws_organizations_organization.infrahouse.roots[0].id
-}
-
-import {
-  to = aws_organizations_organizational_unit.deployments
-  id = "ou-k4pv-jvoszl0b"
 }
 
 resource "aws_organizations_organizational_unit" "deployments" {
@@ -57,19 +32,9 @@ resource "aws_organizations_organizational_unit" "deployments" {
   parent_id = aws_organizations_organization.infrahouse.roots[0].id
 }
 
-import {
-  to = aws_organizations_organizational_unit.suspended
-  id = "ou-k4pv-m9l7qrwe"
-}
-
 resource "aws_organizations_organizational_unit" "suspended" {
   name      = "Suspended"
   parent_id = aws_organizations_organization.infrahouse.roots[0].id
-}
-
-import {
-  to = aws_organizations_organizational_unit.security
-  id = "ou-k4pv-n9tx2u2v"
 }
 
 resource "aws_organizations_organizational_unit" "security" {
@@ -77,87 +42,12 @@ resource "aws_organizations_organizational_unit" "security" {
   parent_id = aws_organizations_organization.infrahouse.roots[0].id
 }
 
-import {
-  to = aws_organizations_organizational_unit.policy_staging
-  id = "ou-k4pv-ub39j8u5"
-}
-
 resource "aws_organizations_organizational_unit" "policy_staging" {
   name      = "Policy Staging"
   parent_id = aws_organizations_organization.infrahouse.roots[0].id
 }
 
-import {
-  to = aws_organizations_organizational_unit.workloads
-  id = "ou-k4pv-xn24jiri"
-}
-
 resource "aws_organizations_organizational_unit" "workloads" {
   name      = "Workloads"
   parent_id = aws_organizations_organization.infrahouse.roots[0].id
-}
-
-import {
-  to = aws_organizations_account.cicd
-  id = "303467602807"
-}
-
-resource "aws_organizations_account" "cicd" {
-  name              = "CI-CD"
-  email             = "billing+cicd@infrahouse.com"
-  parent_id         = aws_organizations_organizational_unit.infrastructure.id
-  close_on_deletion = false
-  create_govcloud   = false
-}
-
-import {
-  to = aws_organizations_account.log_archive
-  id = "338531211565"
-}
-
-resource "aws_organizations_account" "log_archive" {
-  name              = "Log Archive"
-  email             = "billing+log-archive@infrahouse.com"
-  parent_id         = aws_organizations_organizational_unit.security.id
-  close_on_deletion = false
-  create_govcloud   = false
-}
-
-import {
-  to = aws_organizations_account.audit
-  id = "076816212431"
-}
-
-resource "aws_organizations_account" "audit" {
-  name              = "Audit"
-  email             = "billing+audit@infrahouse.com"
-  parent_id         = aws_organizations_organizational_unit.security.id
-  close_on_deletion = false
-  create_govcloud   = false
-}
-
-import {
-  to = aws_organizations_account.management
-  id = "493370826424"
-}
-
-resource "aws_organizations_account" "management" {
-  name              = "InfraHouse Management"
-  email             = "billing+management@infrahouse.com"
-  parent_id         = aws_organizations_organizational_unit.production.id
-  close_on_deletion = false
-  create_govcloud   = false
-}
-
-import {
-  to = aws_organizations_account.terraform_control
-  id = "289256138624"
-}
-
-resource "aws_organizations_account" "terraform_control" {
-  name              = "terraform-control"
-  email             = "billing+terraform-control@infrahouse.com"
-  parent_id         = aws_organizations_organizational_unit.production.id
-  close_on_deletion = false
-  create_govcloud   = false
 }

--- a/organizations_account.tf
+++ b/organizations_account.tf
@@ -1,0 +1,39 @@
+resource "aws_organizations_account" "cicd" {
+  name              = "CI-CD"
+  email             = "billing+cicd@infrahouse.com"
+  parent_id         = aws_organizations_organizational_unit.infrastructure.id
+  close_on_deletion = false
+  create_govcloud   = false
+}
+
+resource "aws_organizations_account" "log_archive" {
+  name              = "Log Archive"
+  email             = "billing+log-archive@infrahouse.com"
+  parent_id         = aws_organizations_organizational_unit.security.id
+  close_on_deletion = false
+  create_govcloud   = false
+}
+
+resource "aws_organizations_account" "audit" {
+  name              = "Audit"
+  email             = "billing+audit@infrahouse.com"
+  parent_id         = aws_organizations_organizational_unit.security.id
+  close_on_deletion = false
+  create_govcloud   = false
+}
+
+resource "aws_organizations_account" "management" {
+  name              = "InfraHouse Management"
+  email             = "billing+management@infrahouse.com"
+  parent_id         = aws_organizations_organizational_unit.production.id
+  close_on_deletion = false
+  create_govcloud   = false
+}
+
+resource "aws_organizations_account" "terraform_control" {
+  name              = "terraform-control"
+  email             = "billing+terraform-control@infrahouse.com"
+  parent_id         = aws_organizations_organizational_unit.production.id
+  close_on_deletion = false
+  create_govcloud   = false
+}


### PR DESCRIPTION
Import AWSControlTowerBaseline for all 7 OUs. Account-level baselines
(IdentityCenter, Audit, LogArchive) are commented out pending a fix for
hashicorp/terraform-provider-aws#45871.
